### PR TITLE
Spring Boot 1.1.6 対応

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url "http://repo.spring.io/milestone" }
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.3.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.1.6.RELEASE")
         classpath("org.springframework:springloaded:1.2.1.BUILD-SNAPSHOT")
     }
 }
@@ -44,7 +44,7 @@ dependencies {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.0'
+    gradleVersion = '2.1'
 }
 
 apply from:'eclipse.gradle'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jul 01 17:43:41 JST 2014
+#Sat Sep 13 20:43:43 JST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip

--- a/src/main/java/sample/web/WebSecurityConfiguration.java
+++ b/src/main/java/sample/web/WebSecurityConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
@@ -36,15 +37,7 @@ import sample.service.AccountService;
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
-    private AccountService accountService;
-
-    @Autowired
     private DataSource dataSource;
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 
     @Bean
     public PersistentTokenRepository persistentTokenRepository() {
@@ -65,11 +58,22 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.rememberMe().tokenRepository(persistentTokenRepository());
     }
 
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth)
-            throws Exception {
-        auth.userDetailsService(accountService).passwordEncoder(
-                passwordEncoder());
-    }
+    @Configuration
+    protected static class AuthenticationConfiguration extends
+            GlobalAuthenticationConfigurerAdapter {
 
+        @Autowired
+        private AccountService accountService;
+
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+            return new BCryptPasswordEncoder();
+        }
+
+        @Override
+        public void init(AuthenticationManagerBuilder auth) throws Exception {
+            auth.userDetailsService(accountService).passwordEncoder(
+                    passwordEncoder());
+        }
+    }
 }


### PR DESCRIPTION
Spring Boot を 1.1.6 にバージョンアップしてみたところ、Springの初期化でエラーが出るようになったため、
sample.web.WebSecurityConfiguration を修正してみました。
また、Gradleのバージョンを2.1に上げています。
